### PR TITLE
Parallel publish and listen

### DIFF
--- a/cmd/wal-listener/init.go
+++ b/cmd/wal-listener/init.go
@@ -47,7 +47,8 @@ func (l pgxLogger) Log(_ pgx.LogLevel, msg string, _ map[string]any) {
 }
 
 type eventPublisher interface {
-	Publish(context.Context, string, *publisher.Event) error
+	Publish(context.Context, string, *publisher.Event) publisher.PublishResult
+	Flush(string)
 	Close() error
 }
 

--- a/listener/publisher_mock_test.go
+++ b/listener/publisher_mock_test.go
@@ -12,7 +12,9 @@ type publisherMock struct {
 	mock.Mock
 }
 
-func (p *publisherMock) Publish(ctx context.Context, subject string, event *publisher.Event) error {
+func (p *publisherMock) Publish(ctx context.Context, subject string, event *publisher.Event) publisher.PublishResult {
 	args := p.Called(ctx, subject, event)
-	return args.Error(0)
+	return publisher.NewPublishResult(args.Error(0))
 }
+
+func (p *publisherMock) Flush(subject string) {}

--- a/publisher/kafka.go
+++ b/publisher/kafka.go
@@ -23,18 +23,20 @@ func NewKafkaPublisher(producer sarama.SyncProducer) *KafkaPublisher {
 	return &KafkaPublisher{producer: producer}
 }
 
-func (p *KafkaPublisher) Publish(_ context.Context, topic string, event *Event) error {
+func (p *KafkaPublisher) Publish(_ context.Context, topic string, event *Event) PublishResult {
 	data, err := json.Marshal(event)
 	if err != nil {
-		return fmt.Errorf("marshal: %w", err)
+		return NewPublishResult(fmt.Errorf("marshal: %w", err))
 	}
 
 	if _, _, err = p.producer.SendMessage(prepareMessage(topic, data)); err != nil {
-		return fmt.Errorf("send message: %w", err)
+		return NewPublishResult(fmt.Errorf("send message: %w", err))
 	}
 
-	return nil
+	return NewPublishResult(nil)
 }
+
+func (p *KafkaPublisher) Flush(topic string) {}
 
 // Close connection close.
 func (p *KafkaPublisher) Close() error {

--- a/publisher/nats.go
+++ b/publisher/nats.go
@@ -33,18 +33,20 @@ func (n NatsPublisher) Close() error {
 }
 
 // Publish serializes the event and publishes it on the bus.
-func (n NatsPublisher) Publish(_ context.Context, subject string, event *Event) error {
+func (n NatsPublisher) Publish(_ context.Context, subject string, event *Event) PublishResult {
 	msg, err := json.Marshal(event)
 	if err != nil {
-		return fmt.Errorf("marshal err: %w", err)
+		return NewPublishResult(fmt.Errorf("marshal err: %w", err))
 	}
 
 	if _, err := n.js.Publish(subject, msg); err != nil {
-		return fmt.Errorf("failed to publish: %w", err)
+		return NewPublishResult(fmt.Errorf("failed to publish: %w", err))
 	}
 
-	return nil
+	return NewPublishResult(nil)
 }
+
+func (n NatsPublisher) Flush(subject string) {}
 
 // CreateStream creates a stream by using JetStreamContext. We can do it manually.
 func (n NatsPublisher) CreateStream(streamName string) error {

--- a/publisher/pubsub.go
+++ b/publisher/pubsub.go
@@ -20,13 +20,17 @@ func NewGooglePubSubPublisher(pubSubConnection *PubSubConnection) *GooglePubSubP
 }
 
 // Publish send events, implements eventPublisher.
-func (p *GooglePubSubPublisher) Publish(ctx context.Context, topic string, event *Event) error {
+func (p *GooglePubSubPublisher) Publish(ctx context.Context, topic string, event *Event) PublishResult {
 	body, err := json.Marshal(event)
 	if err != nil {
-		return fmt.Errorf("marshal: %w", err)
+		return NewPublishResult(fmt.Errorf("marshal: %w", err))
 	}
 
 	return p.pubSubConnection.Publish(ctx, topic, body)
+}
+
+func (p *GooglePubSubPublisher) Flush(topic string) {
+	p.pubSubConnection.Flush(topic)
 }
 
 func (p *GooglePubSubPublisher) Close() error {

--- a/publisher/rabbit.go
+++ b/publisher/rabbit.go
@@ -26,22 +26,24 @@ func NewRabbitPublisher(pubTopic string, conn *rabbitmq.Conn, publisher *rabbitm
 }
 
 // Publish send events, implements eventPublisher.
-func (p *RabbitPublisher) Publish(ctx context.Context, topic string, event *Event) error {
+func (p *RabbitPublisher) Publish(ctx context.Context, topic string, event *Event) PublishResult {
 	const contentTypeJSON = "application/json"
 
 	body, err := json.Marshal(event)
 	if err != nil {
-		return err
+		return NewPublishResult(err)
 	}
 
-	return p.publisher.PublishWithContext(
+	return NewPublishResult(p.publisher.PublishWithContext(
 		ctx,
 		body,
 		[]string{topic},
 		rabbitmq.WithPublishOptionsContentType(contentTypeJSON),
 		rabbitmq.WithPublishOptionsExchange(p.pt),
-	)
+	))
 }
+
+func (p *RabbitPublisher) Flush(topic string) {}
 
 // Close represent finalization for RabbitMQ publisher.
 func (p *RabbitPublisher) Close() error {

--- a/publisher/result.go
+++ b/publisher/result.go
@@ -1,0 +1,20 @@
+package publisher
+
+import "context"
+
+type PublishResult interface {
+	Get(ctx context.Context) (serverID string, err error)
+}
+
+type result struct {
+	serverID string
+	err      error
+}
+
+func NewPublishResult(err error) PublishResult {
+	return &result{serverID: "na", err: err}
+}
+
+func (r *result) Get(ctx context.Context) (string, error) {
+	return r.serverID, r.err
+}


### PR DESCRIPTION
A couple notes about this PR.

This takes a lot of inspiration from what's on our fork's master, but focuses just on `listener.Stream()`. I'm going to follow up with a couple more PRs to capture everything.

Also this is a PR into `upstream` (which is exactly what's in the upstream repo). I can't merge this into master without a bunch of annoying conflicts since I was working off of `upstream`.

Things that are missing from this PR:
- Config changes to handle table regexes (this exists on `master`)
- Proper error handling when errors emerge, right now it tears down the whole stream

A bit of an overview of the difference.

On main how this works is:
- A WAL message is read from PG
- It is then processed into a batch of events
- Each event is published serially to Pubsub
- After each individual message the publisher is flushed

In this PR we break the steps up into 4 and use buffered channels to send messages between them. We don't introduce any parallel processing as we want the order of events to be exactly the same as they came in, but we allow for some stages of the pipeline to continue working while others wait.

For example, while we are waiting for a publish result to finalize we can keeping pulling new messages from PG or parsing existing batches.