### PR TITLE
Lower 'event was sent' log to debug

### DIFF
--- a/listener/listener.go
+++ b/listener/listener.go
@@ -449,7 +449,7 @@ func (l *Listener) Stream(ctx context.Context) error {
 					l.log.Warn("failed to publish message", slog.Any("error", err), slog.String("subjectName", subjectName), slog.String("table", event.Table), slog.String("action", event.Action))
 				} else {
 					l.monitor.IncPublishedEvents(subjectName, event.Table)
-					l.log.Info(
+					l.log.Debug(
 						"event was sent",
 						slog.String("subject", subjectName),
 						slog.String("action", event.Action),


### PR DESCRIPTION
I want to set the wal-listener's log level to info so I can see the log I added in #13, but I don't want this "event was sent" log to go off like crazy, so I'm just gonna lower this to debug.