### PR TITLE
Handle null restart_lsn

### DIFF
--- a/listener/repository.go
+++ b/listener/repository.go
@@ -19,16 +19,16 @@ func NewRepository(conn *pgx.Conn) *RepositoryImpl {
 
 // GetSlotLSN returns the value of the last offset for a specific slot.
 func (r RepositoryImpl) GetSlotLSN(slotName string) (string, error) {
-	var restartLSNStr string
+	var restartLSNStr *string
 
 	err := r.conn.QueryRow("SELECT restart_lsn FROM pg_replication_slots WHERE slot_name=$1;", slotName).
 		Scan(&restartLSNStr)
 
-	if errors.Is(err, pgx.ErrNoRows) {
+	if errors.Is(err, pgx.ErrNoRows) || restartLSNStr == nil {
 		return "", nil
 	}
 
-	return restartLSNStr, err
+	return *restartLSNStr, err
 }
 
 // CreatePublication create publication fo all.


### PR DESCRIPTION
Our wal-listener died and failed to restart because it was trying to scan `NULL` into a `string`:

```
2024/09/19 20:34:59 ERROR service process failed err="slot is exists: get slot lsn: can't scan into dest[0]: cannot assign NULL to *string"
```