### PR TITLE
Handle null `restart_lsn` v2

### DIFF
--- a/listener/listener_test.go
+++ b/listener/listener_test.go
@@ -33,7 +33,7 @@ func TestListener_slotIsExists(t *testing.T) {
 
 	setGetSlotLSN := func(slotName, lsn string, err error) {
 		repo.On("GetSlotLSN", slotName).
-			Return(lsn, err).
+			Return(&lsn, err).
 			Once()
 	}
 	tests := []struct {
@@ -63,7 +63,7 @@ func TestListener_slotIsExists(t *testing.T) {
 				slotName: "myslot",
 			},
 			want:    false,
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "invalid lsn",
@@ -801,7 +801,7 @@ func TestListener_Process(t *testing.T) {
 	}
 
 	setGetSlotLSN := func(slotName string, lsn string, err error) {
-		repo.On("GetSlotLSN", slotName).Return(lsn, err).Once()
+		repo.On("GetSlotLSN", slotName).Return(&lsn, err).Once()
 	}
 
 	setStartReplication := func(
@@ -809,7 +809,8 @@ func TestListener_Process(t *testing.T) {
 		slotName string,
 		startLsn uint64,
 		timeline int64,
-		pluginArguments ...string) {
+		pluginArguments ...string,
+	) {
 		repl.On("StartReplication", slotName, startLsn, timeline, pluginArguments).Return(err).Once()
 	}
 
@@ -968,7 +969,7 @@ func TestListener_Process(t *testing.T) {
 			setup: func() {
 				ctx, _ = context.WithTimeout(ctx, time.Millisecond*20)
 				setCreatePublication("wal-listener", nil)
-				setGetSlotLSN("slot1", "", nil)
+				setGetSlotLSN("slot1", "", pgx.ErrNoRows)
 				setCreateReplicationSlotEx(
 					"slot1",
 					"pgoutput",

--- a/listener/parser_test.go
+++ b/listener/parser_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/ihippik/wal-listener/v2/config"
 	"github.com/jackc/pgx/pgtype"
 	"github.com/stretchr/testify/assert"
 )
@@ -487,7 +488,7 @@ func TestBinaryParser_ParseWalMessage(t *testing.T) {
 					0, 0, 0, 0, 0, 0, 0, 0,
 					0, 0, 0, 5,
 				},
-				tx: NewWalTransaction(logger, nil, metrics, nil, nil, nil),
+				tx: NewWalTransaction(logger, nil, metrics, nil, config.ExcludeStruct{}),
 			},
 			want: &WalTransaction{
 				pool:          nil,

--- a/listener/repository.go
+++ b/listener/repository.go
@@ -3,6 +3,7 @@ package listener
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx"
 )
@@ -33,7 +34,7 @@ func (r RepositoryImpl) GetSlotLSN(slotName string) (string, error) {
 
 // CreatePublication create publication fo all.
 func (r RepositoryImpl) CreatePublication(name string) error {
-	if _, err := r.conn.Exec(`CREATE PUBLICATION "` + name + `" FOR ALL TABLES`); err != nil {
+	if _, err := r.conn.Exec(`CREATE PUBLICATION "` + name + `" FOR ALL TABLES`); err != nil && !strings.Contains("already exists", err.Error()) {
 		return fmt.Errorf("exec: %w", err)
 	}
 

--- a/listener/repository.go
+++ b/listener/repository.go
@@ -1,7 +1,6 @@
 package listener
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -19,17 +18,13 @@ func NewRepository(conn *pgx.Conn) *RepositoryImpl {
 }
 
 // GetSlotLSN returns the value of the last offset for a specific slot.
-func (r RepositoryImpl) GetSlotLSN(slotName string) (string, error) {
+func (r RepositoryImpl) GetSlotLSN(slotName string) (*string, error) {
 	var restartLSNStr *string
 
 	err := r.conn.QueryRow("SELECT restart_lsn FROM pg_replication_slots WHERE slot_name=$1;", slotName).
 		Scan(&restartLSNStr)
 
-	if errors.Is(err, pgx.ErrNoRows) || restartLSNStr == nil {
-		return "", nil
-	}
-
-	return *restartLSNStr, err
+	return restartLSNStr, err
 }
 
 // CreatePublication create publication fo all.

--- a/listener/repository_mock_test.go
+++ b/listener/repository_mock_test.go
@@ -9,9 +9,9 @@ type repositoryMock struct {
 	mock.Mock
 }
 
-func (r *repositoryMock) GetSlotLSN(slotName string) (string, error) {
+func (r *repositoryMock) GetSlotLSN(slotName string) (*string, error) {
 	args := r.Called(slotName)
-	return args.Get(0).(string), args.Error(1)
+	return args.Get(0).(*string), args.Error(1)
 }
 
 func (r *repositoryMock) IsAlive() bool {


### PR DESCRIPTION
The wal-listener crashed again and failed to restart because the `restart_lsn` was NULL. The wal-listener was able to load the replication slot row with a NULL `restart_lsn` (which is what #16 fixed), but it assumed the replication slot didn't exist and would crash when it tried to create it.

This PR fixes that issue by dropping the replication when the `restart_lsn` is NULL. This will cause us to lose WAL messages so I've made sure to log an error that we can monitor and be alerted when this happens.
- [Drop the replication slot if restart_lsn is NULL](https://github.com/gadget-inc/wal-listener/commit/3f3c12bb593a34736839366bad6b3a1cd17e74c4)

As for why the wal-listener crashed in the first place, it looks like it stopped receiving replication messages for 15 minutes, causing Postgres to truncate the replication slot because it reached its max_slot_wal_keep_size. The wal-listener then crashed with the following error message immediately after the WAL was truncated:

```
2024/10/04 13:50:13 ERROR service process failed err="wait for replication message: FATAL: terminating connection due to administrator command (SQLSTATE 57P01)"
```

We don't know why the wal-listener stopped receiving replication messages, but the upstream wal-listener repo merged a bug fix that might be related, so this PR backports it.
- [Ensure we process ServerHeartbeat messages](https://github.com/gadget-inc/wal-listener/commit/2c1733c88bc7161d7e88dc46eb57a4f6fda251a5)
	- related: https://github.com/ihippik/wal-listener/pull/43