### PR TITLE
Resume paused topics and retry

### DIFF
--- a/publisher/pubsub_connection.go
+++ b/publisher/pubsub_connection.go
@@ -67,10 +67,17 @@ func (c *PubSubConnection) getTopic(topic string) *pubsub.Topic {
 func (c *PubSubConnection) Publish(ctx context.Context, topic string, data []byte, orderingKey string) PublishResult {
 	t := c.getTopic(topic)
 
-	return t.Publish(ctx, &pubsub.Message{
+	result := t.Publish(ctx, &pubsub.Message{
 		Data:        data,
 		OrderingKey: orderingKey,
 	})
+
+	return &retryPausedResult{
+		inner:       result,
+		topic:       t,
+		data:        data,
+		orderingKey: orderingKey,
+	}
 }
 
 func (c *PubSubConnection) Flush(topic string) {
@@ -80,4 +87,27 @@ func (c *PubSubConnection) Flush(topic string) {
 
 func (c *PubSubConnection) Close() error {
 	return c.client.Close()
+}
+
+type retryPausedResult struct {
+	inner       *pubsub.PublishResult
+	topic       *pubsub.Topic
+	data        []byte
+	orderingKey string
+}
+
+func (r *retryPausedResult) Get(ctx context.Context) (string, error) {
+	serverID, err := r.inner.Get(ctx)
+
+	if err != nil && errors.Is(err, pubsub.ErrPublishingPaused{}) {
+		// if we failed to publish because publishing is paused, resume publishing and retry
+		r.topic.ResumePublish(r.orderingKey)
+
+		return r.topic.Publish(ctx, &pubsub.Message{
+			Data:        r.data,
+			OrderingKey: r.orderingKey,
+		}).Get(ctx)
+	}
+
+	return serverID, err
 }

--- a/publisher/pubsub_connection.go
+++ b/publisher/pubsub_connection.go
@@ -2,17 +2,13 @@ package publisher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
 	"time"
 
 	"cloud.google.com/go/pubsub"
-)
-
-const (
-	KB = 1024
-	MB = KB * KB
 )
 
 // PubSubConnection represent Pub/Sub connection.
@@ -55,7 +51,7 @@ func (c *PubSubConnection) getTopic(topic string) *pubsub.Topic {
 
 	t := c.client.TopicInProject(topic, c.projectID)
 	t.EnableMessageOrdering = c.enableOrdering
-	t.PublishSettings.ByteThreshold = 8 * MB
+	t.PublishSettings.ByteThreshold = 1e7
 	t.PublishSettings.DelayThreshold = 250 * time.Millisecond
 	t.PublishSettings.CountThreshold = 150
 


### PR DESCRIPTION
The wal-listener is logging this error a lot:
```
pubsub: Publishing for ordering key, 829c272d0236d8bcd6932e384c5b97d0c36e4f1e20255d3cf86f7a4e6e16646ad2f4ab08c609a73349e2aaf6f0e7eb44f93c60089dd027fee7f46c9e6a4cef65, paused due to previous error. Call topic.ResumePublish(orderingKey) before resuming publishing
```

When we fail to publish a message to a topic, all future attempts to publish a message with the same `orderingKey` are rejected until the topic is resumed. This PR makes us resume the topic and tries to publish the message again when that error is encountered.
- [Resume paused topics and retry](https://github.com/gadget-inc/wal-listener/pull/19/commits/291eb728c9f65b6314639aa9b64cdca073cde435)

I found this log when looking for the "previous error" that caused the topic to be paused:
```
item size exceeds bundle byte limit
```

The "item size exceeds bundle byte limit" error happens when we attempt to publish a message greater than `PublishSettings.ByteThreshold`, so I bumped the limit from 8MB to 10MB because that's the limit pusub supports.
- [Bump ByteThreshold to 10MB](https://github.com/gadget-inc/wal-listener/pull/19/commits/87d3ac4aa663ab63b066dfdb0e9e69c9bb68e24e)
- https://cloud.google.com/pubsub/quotas
   ![CleanShot 2024-10-08 at 14 08 10@2x](https://github.com/user-attachments/assets/f6965dce-60a4-465d-b89e-ceafe3149596)

I also made sure to log the id of the record associated with messages that we fail to publish to pubsub. This way we can inspect the records and potentially recover them later.
- [Add recordId to "fail to publish" log](https://github.com/gadget-inc/wal-listener/pull/19/commits/a1cde496791edd164f5c44e5b865f77f8a74c851)