### PR TITLE
Add stdout publisher to debug locally

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,7 @@
 docker
 certs
 Dockerfile
+.envrc
+nix
+tmp
+scripts

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,11 @@
+# shellcheck shell=bash
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.5; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.5/direnvrc" "sha256-RuwIS+QKFj/T9M2TFXScjBsLR6V3A17YVoEW/Q6AZ1w="
+fi
+
+watch_file nix/flake.nix
+watch_file nix/flake.lock
+
+use flake path:"$PWD"/nix
+
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 # vendor/
 config.yml
 certs/*
+
+tmp/
+.direnv/

--- a/cmd/wal-listener/init.go
+++ b/cmd/wal-listener/init.go
@@ -63,6 +63,8 @@ type eventPublisher interface {
 // factoryPublisher represents a factory function for creating a eventPublisher.
 func factoryPublisher(ctx context.Context, cfg *config.PublisherCfg, logger *slog.Logger) (eventPublisher, error) {
 	switch cfg.Type {
+	case config.PublisherTypeStdout:
+		return publisher.NewStdoutPublisher(), nil
 	case config.PublisherTypeKafka:
 		producer, err := publisher.NewProducer(cfg)
 		if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ import (
 type PublisherType string
 
 const (
+	PublisherTypeStdout       PublisherType = "stdout"
 	PublisherTypeNats         PublisherType = "nats"
 	PublisherTypeKafka        PublisherType = "kafka"
 	PublisherTypeRabbitMQ     PublisherType = "rabbitmq"

--- a/config_stdout_example.yml
+++ b/config_stdout_example.yml
@@ -1,0 +1,20 @@
+listener:
+  slotName: wal_development
+  refreshConnection: 30s
+  heartbeatInterval: 10s
+  topicsMap:
+    /(.+)/: "all"
+logger:
+  level: warn
+  fmt: text
+database:
+  host: localhost
+  port: 5432
+  name: wal_development
+  user: wal_development
+  password: wal_development
+publisher:
+  type: stdout
+  topic: "does not matter"
+monitoring:
+  promAddr: ":2112"

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1738009863,
+        "narHash": "sha256-KxmFlQ2j9PpDhKRXWu85bv3R2wmfkUqdpJhEwz9JN/E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f898cbfddfab52593da301a397a17d0af801bbc3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "wal-listener development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    (flake-utils.lib.eachDefaultSystem (system: nixpkgs.lib.fix (flake:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages = {
+          direnv = pkgs.direnv;
+          git = pkgs.git;
+          postgresql = pkgs.postgresql_13;
+        };
+
+        devShell = pkgs.mkShell {
+          packages = builtins.attrValues flake.packages;
+        };
+      }
+    )));
+}

--- a/publisher/stdout.go
+++ b/publisher/stdout.go
@@ -1,0 +1,27 @@
+package publisher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type StdoutPublisher struct{}
+
+func NewStdoutPublisher() *StdoutPublisher {
+	return &StdoutPublisher{}
+}
+
+func (p *StdoutPublisher) Publish(ctx context.Context, topic string, event *Event) PublishResult {
+	body, err := json.MarshalIndent(event, "", "  ")
+	if err != nil {
+		return NewPublishResult(err)
+	}
+
+	fmt.Println(string(body))
+	return NewPublishResult(nil)
+}
+
+func (p *StdoutPublisher) Flush(topic string) {}
+
+func (p *StdoutPublisher) Close() error { return nil }

--- a/scripts/setup-postgres.sh
+++ b/scripts/setup-postgres.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+export PGDATA=tmp/postgres-13
+export PGHOST=127.0.0.1
+export PGDATABASE=wal_development
+export PGUSER=wal_development
+export PGPASSWORD=wal_development
+export PGURI="postgres://$PGUSER:$PGPASSWORD@$PGHOST"
+export PGOPTIONS=" -c timezone=UTC -c synchronous_commit=off -c client_min_messages=warning"
+
+wait_for_postgres() {
+    until psql --no-psqlrc "$PGURI/postgres" -c '\q' 2>/dev/null; do
+        sleep 0.2
+    done
+}
+
+database_exists() {
+    if [[ "$(psql --no-psqlrc "$PGURI/postgres" -qtAc "SELECT 1 FROM pg_database WHERE datname = '$1'")" == "1" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+create_database() {
+    psql --no-psqlrc "$PGURI/postgres" -c "CREATE DATABASE \"$1\";"
+}
+
+wait_for_postgres
+
+if ! database_exists "$PGDATABASE"; then
+    echo "== Creating postgres database =="
+    create_database "$PGDATABASE"
+fi

--- a/scripts/start-postgres.sh
+++ b/scripts/start-postgres.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+export PGDATA=tmp/postgres-13
+export PGHOST=127.0.0.1
+export PGDATABASE=wal_development
+export PGUSER=wal_development
+export PGPASSWORD=wal_development
+export PGURI="postgres://$PGUSER:$PGPASSWORD@$PGHOST"
+export PGOPTIONS=" -c timezone=UTC -c synchronous_commit=off -c client_min_messages=warning"
+
+if [[ ! -d "$PGDATA" ]]; then
+    echo "== Creating postgres database cluster =="
+    initdb --username="$PGUSER" --pwfile=<(echo "$PGPASSWORD") --locale=C
+fi
+
+postgres -c unix_socket_directories= -c fsync=off -c full_page_writes=off -c max_connections=500 -c wal_level=logical


### PR DESCRIPTION
This adds a new publisher that prints to stdout so we can easily debug what the wal listener is trying to publish.

You can run with the stdout publisher via:

```sh
go run ./cmd/wal-listener/ --config ./config_stdout_example.yml
```

I also made a script to setup a local database

```sh
scripts/start-postgres.sh
```

then in another tab
```sh
scripts/setup-postgres.sh
```