### PR TITLE
Copy unchanged toasted values from dataOld to data

### DIFF
--- a/listener/parser.go
+++ b/listener/parser.go
@@ -322,6 +322,7 @@ func (p *BinaryParser) readTupleData() []TupleData {
 			p.log.Debug("tupleData: null data type")
 		case ToastDataType:
 			p.log.Debug("tupleData: toast data type")
+			data[i] = TupleData{IsUnchangedToastedValue: true}
 		case TextDataType:
 			vSize := int(p.readInt32())
 			data[i] = TupleData{Value: p.buffer.Next(vSize)}

--- a/listener/protocol.go
+++ b/listener/protocol.go
@@ -165,5 +165,6 @@ type RelationColumn struct {
 
 // TupleData path of WAL message data.
 type TupleData struct {
-	Value []byte
+	Value                   []byte
+	IsUnchangedToastedValue bool
 }

--- a/listener/wal_transaction.go
+++ b/listener/wal_transaction.go
@@ -217,7 +217,11 @@ func (w *WalTransaction) CreateActionData(
 			valueType: rel.Columns[num].valueType,
 			isKey:     rel.Columns[num].isKey,
 		}
-		column.AssertValue(row.Value)
+		if row.IsUnchangedToastedValue && len(oldRows) > num {
+			column.AssertValue(oldRows[num].Value)
+		} else {
+			column.AssertValue(row.Value)
+		}
 		newColumns = append(newColumns, column)
 	}
 

--- a/publisher/event.go
+++ b/publisher/event.go
@@ -10,14 +10,15 @@ import (
 
 // Event structure for publishing to the NATS server.
 type Event struct {
-	ID         uuid.UUID      `json:"id"`
-	Schema     string         `json:"schema"`
-	Table      string         `json:"table"`
-	Action     string         `json:"action"`
-	Data       map[string]any `json:"data"`
-	DataOld    map[string]any `json:"dataOld"`
-	EventTime  time.Time      `json:"commitTime"`
-	PrimaryKey []string       `json:"primaryKey"`
+	ID                     uuid.UUID      `json:"id"`
+	Schema                 string         `json:"schema"`
+	Table                  string         `json:"table"`
+	Action                 string         `json:"action"`
+	Data                   map[string]any `json:"data"`
+	DataOld                map[string]any `json:"dataOld"`
+	EventTime              time.Time      `json:"commitTime"`
+	PrimaryKey             []string       `json:"primaryKey"`
+	UnchangedToastedValues []string       `json:"unchangedToastedValues"`
 }
 
 // SubjectName creates subject name from the prefix, schema and table name. Also using topic map from cfg.


### PR DESCRIPTION
Given a table with `REPLICA IDENTITY FULL` and rows with [toasted](https://www.postgresql.org/docs/13/storage-toast.html) values:

```sql
CREATE TABLE todos (
	id serial PRIMARY KEY,
	content text NOT NULL,
	is_complete boolean NOT NULL DEFAULT FALSE,
	created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
	updated_at timestamptz NOT NULL DEFAULT statement_timestamp()
);

ALTER TABLE todos REPLICA IDENTITY FULL;

INSERT INTO todos (content) VALUES ('some large toasted value');
```

The wal listener will publish the following event:

```json
{
  "id": "4bce63dc-2061-4f2d-921d-0c31afe34a4a",
  "schema": "public",
  "table": "todos",
  "action": "INSERT",
  "data": {
    "content": "some large toasted value",
    "created_at": "2025-01-28T18:03:35.6839-05:00",
    "id": 1,
    "is_complete": false,
    "updated_at": "2025-01-28T18:03:35.6839-05:00"
  },
  "dataOld": {},
  "commitTime": "2025-01-28T23:03:35.685402Z",
  "primaryKey": [
    "1",
    "some large toasted value",
    "false",
    "2025-01-28 18:03:35.6839 -0500 -0500",
    "2025-01-28 18:03:35.6839 -0500 -0500"
  ]
}
```

When the row is partially updated without the toasted value, e.g.

```sql
UPDATE todos SET is_complete = TRUE WHERE id = 1;
```

Then postgres sends the toasted value within the old tuple but doesn't send the toasted value in the new tuple. [Instead it sends a byte representing that the toasted value didn't change](https://www.postgresql.org/docs/13/protocol-logicalrep-message-formats.html#:~:text=Or-,Byte1(%27u%27),Identifies%20unchanged%20TOASTed%20value%20(the%20actual%20value%20is%20not%20sent).,-Or).

This causes the wal listener to publish the following event:

```json
{
  "id": "56b72642-d9a5-4592-adbd-a1465915c0d3",
  "schema": "public",
  "table": "todos",
  "action": "UPDATE",
  "data": {
    "content": null,
    "created_at": "2025-01-28T18:06:25.073323-05:00",
    "id": 1,
    "is_complete": true,
    "updated_at": "2025-01-28T18:06:25.073323-05:00"
  },
  "dataOld": {
    "content": "some large toasted value",
    "created_at": "2025-01-28T18:06:25.073323-05:00",
    "id": 1,
    "is_complete": false,
    "updated_at": "2025-01-28T18:06:25.073323-05:00"
  },
  "commitTime": "2025-01-28T23:06:28.376174Z",
  "primaryKey": [
    "1",
    "some large toasted value",
    "true",
    "2025-01-28 18:06:25.073323 -0500 -0500",
    "2025-01-28 18:06:25.073323 -0500 -0500"
  ]
}
```

Notice how `content` is `null` in `data` but present in `dataOld`, as if `content` was set to `null` by the update, when in reality the value was omitted by postgres.

This PR changes the wal listener to keep track of unchanged toasted values and:
1. copies the unchanged toasted value from `dataOld` to `data`
2. removes the column from `dataOld`
3. adds the column name to `unchangedToastedValues`

This makes the wal listener publish the following event instead:

```json
{
  "id": "56b72642-d9a5-4592-adbd-a1465915c0d3",
  "schema": "public",
  "table": "todos",
  "action": "UPDATE",
  "data": {
    "content": "some large toasted value",
    "created_at": "2025-01-28T18:06:25.073323-05:00",
    "id": 1,
    "is_complete": true,
    "updated_at": "2025-01-28T18:06:25.073323-05:00"
  },
  "dataOld": {
    "created_at": "2025-01-28T18:06:25.073323-05:00",
    "id": 1,
    "is_complete": false,
    "updated_at": "2025-01-28T18:06:25.073323-05:00"
  },
  "commitTime": "2025-01-28T23:06:28.376174Z",
  "primaryKey": [
    "1",
    "some large toasted value",
    "true",
    "2025-01-28 18:06:25.073323 -0500 -0500",
    "2025-01-28 18:06:25.073323 -0500 -0500"
  ],
  "unchangedToastedValues": [
    "content"
  ]
}
```