### PR TITLE
Remove primary key from publish events

### DIFF
--- a/listener/listener.go
+++ b/listener/listener.go
@@ -491,7 +491,6 @@ func (l *Listener) Stream(ctx context.Context) error {
 							slog.Any("error", err),
 							slog.String("subjectName", subjectName),
 							slog.String("table", event.Table),
-							slog.Any("primaryKey", event.PrimaryKey),
 							slog.String("action", event.Action),
 						)
 					} else {

--- a/listener/wal_transaction.go
+++ b/listener/wal_transaction.go
@@ -3,7 +3,6 @@ package listener
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -261,8 +260,6 @@ func (w *WalTransaction) CreateEventsWithFilter(ctx context.Context) []*publishe
 
 		data := make(map[string]any, len(item.NewColumns))
 
-		var primaryKey []string
-
 		for _, val := range item.NewColumns {
 			if inArray(w.excludes.Columns, val.name) {
 				continue
@@ -271,9 +268,6 @@ func (w *WalTransaction) CreateEventsWithFilter(ctx context.Context) []*publishe
 				unchangedToastedValues = append(unchangedToastedValues, val.name)
 			}
 			data[val.name] = val.value
-			if val.isKey {
-				primaryKey = append(primaryKey, fmt.Sprint(val.value))
-			}
 		}
 
 		event := w.pool.Get().(*publisher.Event)
@@ -284,7 +278,6 @@ func (w *WalTransaction) CreateEventsWithFilter(ctx context.Context) []*publishe
 		event.Data = data
 		event.DataOld = dataOld
 		event.EventTime = *w.CommitTime
-		event.PrimaryKey = primaryKey
 		event.UnchangedToastedValues = unchangedToastedValues
 
 		actions, found := w.includeTableMap[item.Table]

--- a/publisher/event.go
+++ b/publisher/event.go
@@ -17,7 +17,6 @@ type Event struct {
 	Data                   map[string]any `json:"data"`
 	DataOld                map[string]any `json:"dataOld"`
 	EventTime              time.Time      `json:"commitTime"`
-	PrimaryKey             []string       `json:"primaryKey"`
 	UnchangedToastedValues []string       `json:"unchangedToastedValues"`
 }
 

--- a/publisher/pubsub.go
+++ b/publisher/pubsub.go
@@ -2,25 +2,19 @@ package publisher
 
 import (
 	"context"
-	"crypto/sha512"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"hash"
-	"strings"
 )
 
 // GooglePubSubPublisher represent Pub/Sub publisher.
 type GooglePubSubPublisher struct {
 	pubSubConnection *PubSubConnection
-	hasher           hash.Hash
 }
 
 // NewGooglePubSubPublisher create new instance of GooglePubSubPublisher.
 func NewGooglePubSubPublisher(pubSubConnection *PubSubConnection) *GooglePubSubPublisher {
 	return &GooglePubSubPublisher{
 		pubSubConnection: pubSubConnection,
-		hasher:           sha512.New(),
 	}
 }
 
@@ -31,11 +25,7 @@ func (p *GooglePubSubPublisher) Publish(ctx context.Context, topic string, event
 		return NewPublishResult(fmt.Errorf("marshal: %w", err))
 	}
 
-	p.hasher.Reset()
-	p.hasher.Write([]byte(strings.Join(event.PrimaryKey, "-")))
-	orderingKey := hex.EncodeToString(p.hasher.Sum(nil))
-
-	return p.pubSubConnection.Publish(ctx, topic, body, orderingKey)
+	return p.pubSubConnection.Publish(ctx, topic, body)
 }
 
 func (p *GooglePubSubPublisher) Flush(topic string) {


### PR DESCRIPTION
Given a table with `REPLICA IDENTITY FULL`:

```sql
CREATE TABLE todos (
	id serial PRIMARY KEY,
	content text NOT NULL,
	is_complete boolean NOT NULL DEFAULT FALSE,
	created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
	updated_at timestamptz NOT NULL DEFAULT statement_timestamp()
);

ALTER TABLE todos REPLICA IDENTITY FULL;

INSERT INTO todos (content) VALUES ('some value');
```

The wal listener will publish the following event:

```json
{
  "id": "4bce63dc-2061-4f2d-921d-0c31afe34a4a",
  "schema": "public",
  "table": "todos",
  "action": "INSERT",
  "data": {
    "content": "some value",
    "created_at": "2025-01-28T18:03:35.6839-05:00",
    "id": 1,
    "is_complete": false,
    "updated_at": "2025-01-28T18:03:35.6839-05:00"
  },
  "dataOld": {},
  "commitTime": "2025-01-28T23:03:35.685402Z",
  "primaryKey": [
    "1",
    "some value",
    "false",
    "2025-01-28 18:03:35.6839 -0500 -0500",
    "2025-01-28 18:03:35.6839 -0500 -0500"
  ]
}
```

Notice the `primaryKey` contains all the values in `data`. This is because postgres [treats the entire row as the primary key](https://www.postgresql.org/docs/13/logical-replication-publication.html#:~:text=If%20the%20table%20does%20not%20have%20any%20suitable%20key%2C%20then%20it%20can%20be%20set%20to%20replica%20identity%20%E2%80%9Cfull%E2%80%9D%2C%20which%20means%20the%20entire%20row%20becomes%20the%20key) when a table has `REPLICA IDENTITY FULL`.

This PR removes the `primaryKey` from the published event so we don't duplicate all the data and blow past the google pubsub message size limit, e.g.

```json
{
  "id": "4bce63dc-2061-4f2d-921d-0c31afe34a4a",
  "schema": "public",
  "table": "todos",
  "action": "INSERT",
  "data": {
    "content": "some large toasted value",
    "created_at": "2025-01-28T18:03:35.6839-05:00",
    "id": 1,
    "is_complete": false,
    "updated_at": "2025-01-28T18:03:35.6839-05:00"
  },
  "dataOld": {},
  "commitTime": "2025-01-28T23:03:35.685402Z"
}
```

This PR also removes the ability to publish ordering keys to google pubsub because it doesn't work when the table has `REPLICA IDENTITY FULL`. We didn't end up needing ordering keys because all our tables have a `version` column, making it trivial to deal with out of order messages.