### PR TITLE
Downgrade go 1.23.2 -> 1.22.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dependencies Stage
-FROM golang:1.23.2-alpine AS base
+FROM golang:1.22.4-alpine AS base
 LABEL maintainer="Konstantin Makarov <hippik80@gmail.com>"
 
 WORKDIR /listener

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ihippik/wal-listener/v2
 
-go 1.23.2
+go 1.22.4
 
 require (
 	cloud.google.com/go/pubsub v1.37.0


### PR DESCRIPTION
Gadget's nix flake doesn't have go v1.23.2 available and it's impossible to update... let's just downgrade the go version back to v1.22.4, reverting https://github.com/gadget-inc/wal-listener/commit/6bcbf781f5794af91d8d3cf7f85c9e8e696c0b74