### PR TITLE
Downgrade go 1.22.4 -> 1.22.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dependencies Stage
-FROM golang:1.22.4-alpine AS base
+FROM golang:1.22.3-alpine AS base
 LABEL maintainer="Konstantin Makarov <hippik80@gmail.com>"
 
 WORKDIR /listener

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ihippik/wal-listener/v2
 
-go 1.22.4
+go 1.22.3
 
 require (
 	cloud.google.com/go/pubsub v1.37.0


### PR DESCRIPTION
Follow up to https://github.com/gadget-inc/wal-listener/pull/24

Turns out downgrading to v1.22.4 wasn't enough, Gadget's flake only supports go v1.22.3 😭 