### PR TITLE
Don't buffer up actions between begin/commit messages

### DIFF
--- a/listener/listener.go
+++ b/listener/listener.go
@@ -427,15 +427,17 @@ func (l *Listener) Stream(ctx context.Context) error {
 						return fmt.Errorf("parse: %w", err)
 					}
 
-					if tx.CommitTime != nil {
-						events := tx.CreateEventsWithFilter(ctx)
-
-						eventsChan <- &messageAndEvents{
-							xld:    &xld,
-							events: events,
-						}
-						tx.Clear()
+					// TODO buffering will be necessary for streaming messages, but since we're only on protocol version 1
+					//   and using async replication, all messages have been committed on the primary.
+					//   See https://www.postgresql.org/docs/current/warm-standby.html#SYNCHRONOUS-REPLICATION
+					// if tx.CommitTime != nil {
+					events := tx.CreateEventsWithFilter(ctx)
+					eventsChan <- &messageAndEvents{
+						xld:    &xld,
+						events: events,
 					}
+					tx.Clear()
+					// }
 				}
 			}
 		}

--- a/listener/wal_transaction.go
+++ b/listener/wal_transaction.go
@@ -279,7 +279,7 @@ func (w *WalTransaction) CreateEventsWithFilter(ctx context.Context) []*publishe
 		event.Action = item.Kind.string()
 		event.Data = data
 		event.DataOld = dataOld
-		event.EventTime = *w.CommitTime
+		event.EventTime = time.Now()
 		event.UnchangedToastedValues = unchangedToastedValues
 		event.Tags = w.tags
 

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -6,21 +6,34 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    (flake-utils.lib.eachDefaultSystem (system: nixpkgs.lib.fix (flake:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-      in
-      {
-        packages = {
-          direnv = pkgs.direnv;
-          git = pkgs.git;
-          postgresql = pkgs.postgresql_13;
-        };
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    (flake-utils.lib.eachDefaultSystem (
+      system:
+      nixpkgs.lib.fix (
+        flake:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          packages = {
+            direnv = pkgs.direnv;
+            git = pkgs.git;
+            google-cloud-sdk = pkgs.google-cloud-sdk.withExtraComponents ([
+              pkgs.google-cloud-sdk.components.gke-gcloud-auth-plugin
+              pkgs.google-cloud-sdk.components.pubsub-emulator
+            ]);
+            postgresql = pkgs.postgresql_13;
+          };
 
-        devShell = pkgs.mkShell {
-          packages = builtins.attrValues flake.packages;
-        };
-      }
-    )));
+          devShell = pkgs.mkShell {
+            packages = builtins.attrValues flake.packages;
+          };
+        }
+      )
+    ));
 }


### PR DESCRIPTION
As per the Postgres docs, only transactions committed on the primary are sent through, so there's no need for us to build up a big buffer of events.