### PR TITLE
Log retained wal bytes every 60 seconds

### DIFF
--- a/listener/repository.go
+++ b/listener/repository.go
@@ -28,6 +28,16 @@ func (r RepositoryImpl) GetSlotLSN(ctx context.Context, slotName string) (*strin
 	return restartLSNStr, err
 }
 
+// GetSlotRetainedWALBytes returns the retained bytes of the replication slot.
+func (r RepositoryImpl) GetSlotRetainedWALBytes(ctx context.Context, slotName string) (*int64, error) {
+	var retainedWALBytes *int64
+
+	err := r.conn.QueryRow(ctx, "SELECT pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) AS retained_wal_bytes FROM pg_replication_slots WHERE slot_name=$1;", slotName).
+		Scan(&retainedWALBytes)
+
+	return retainedWALBytes, err
+}
+
 // CreatePublication create publication fo all.
 func (r RepositoryImpl) CreatePublication(ctx context.Context, name string) error {
 	if _, err := r.conn.Exec(ctx, `CREATE PUBLICATION "`+name+`" FOR ALL TABLES`); err != nil && !strings.Contains("already exists", err.Error()) {

--- a/listener/repository_mock_test.go
+++ b/listener/repository_mock_test.go
@@ -15,6 +15,11 @@ func (r *repositoryMock) GetSlotLSN(_ context.Context, slotName string) (*string
 	return args.Get(0).(*string), args.Error(1)
 }
 
+func (r *repositoryMock) GetSlotRetainedWALBytes(_ context.Context, slotName string) (*int64, error) {
+	args := r.Called(slotName)
+	return args.Get(0).(*int64), args.Error(1)
+}
+
 func (r *repositoryMock) IsAlive() bool {
 	return r.Called().Bool(0)
 }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -23,6 +23,7 @@
           packages = {
             direnv = pkgs.direnv;
             git = pkgs.git;
+            go = pkgs.go;
             google-cloud-sdk = pkgs.google-cloud-sdk.withExtraComponents ([
               pkgs.google-cloud-sdk.components.gke-gcloud-auth-plugin
               pkgs.google-cloud-sdk.components.pubsub-emulator


### PR DESCRIPTION
We want to log this so we can alert on if the slot is going to reach the `max_slot_wal_keep_size`.

Manually tested using https://github.com/gadget-inc/gadget/pull/17670

<img width="1591" height="63" alt="image" src="https://github.com/user-attachments/assets/ec3a6897-339d-48ef-a75a-76d0dd19936d" />